### PR TITLE
Make Util.isArray accept arraylike objects

### DIFF
--- a/src/core/Util.js
+++ b/src/core/Util.js
@@ -179,8 +179,8 @@ export function template(str, data) {
 // @function isArray(obj): Boolean
 // Compatibility polyfill for [Array.isArray](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray)
 export function isArray(obj) {
-	return obj != null && obj.length >= 0 && typeof obj === 'object';
-	//return (Object.prototype.toString.call(obj) === '[object Array]');
+	return obj !== undefined && obj !== null && obj.length >= 0 && typeof obj === 'object';
+	// return (Object.prototype.toString.call(obj) === '[object Array]');
 }
 
 // @function indexOf(array: Array, el: Object): Number

--- a/src/core/Util.js
+++ b/src/core/Util.js
@@ -179,9 +179,9 @@ export function template(str, data) {
 // @function isArray(obj): Boolean
 // Compatibility polyfill for [Array.isArray](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray)
 export function isArray(obj) {
-	return obj != void 0 && obj.length >= 0 && typeof obj === 'object';
+	return obj != null && obj.length >= 0 && typeof obj === 'object';
 	//return (Object.prototype.toString.call(obj) === '[object Array]');
-};
+}
 
 // @function indexOf(array: Array, el: Object): Number
 // Compatibility polyfill for [Array.prototype.indexOf](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/indexOf)

--- a/src/core/Util.js
+++ b/src/core/Util.js
@@ -179,7 +179,7 @@ export function template(str, data) {
 // @function isArray(obj): Boolean
 // Compatibility polyfill for [Array.isArray](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray)
 export function isArray(obj) {
-	return obj && obj.length >= 0 && typeof obj === 'object';
+	return obj != void 0 && obj.length >= 0 && typeof obj === 'object';
 	//return (Object.prototype.toString.call(obj) === '[object Array]');
 };
 

--- a/src/core/Util.js
+++ b/src/core/Util.js
@@ -179,7 +179,7 @@ export function template(str, data) {
 // @function isArray(obj): Boolean
 // Compatibility polyfill for [Array.isArray](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray)
 export function isArray(obj) {
-	return obj !== undefined && obj !== null && obj.length >= 0 && typeof obj === 'object';
+	return typeof obj === 'object' && obj !== null && obj.length >= 0;
 	// return (Object.prototype.toString.call(obj) === '[object Array]');
 }
 

--- a/src/core/Util.js
+++ b/src/core/Util.js
@@ -178,8 +178,9 @@ export function template(str, data) {
 
 // @function isArray(obj): Boolean
 // Compatibility polyfill for [Array.isArray](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray)
-export var isArray = Array.isArray || function (obj) {
-	return (Object.prototype.toString.call(obj) === '[object Array]');
+export function isArray(obj) {
+	return obj && obj.length >= 0 && typeof obj === 'object';
+	//return (Object.prototype.toString.call(obj) === '[object Array]');
 };
 
 // @function indexOf(array: Array, el: Object): Number

--- a/src/core/Util.js
+++ b/src/core/Util.js
@@ -180,7 +180,7 @@ export function template(str, data) {
 // Compatibility polyfill for [Array.isArray](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray)
 export function isArray(obj) {
 	return typeof obj === 'object' && obj !== null && obj.length >= 0;
-	// return (Object.prototype.toString.call(obj) === '[object Array]');
+	// return Object.prototype.toString.call(obj) === '[object Array]';
 }
 
 // @function indexOf(array: Array, el: Object): Number


### PR DESCRIPTION
It'd be very nice if typed arrays and other arraylike objects would be valid to pass to Leaflet's methods too.
My propose is: `return obj != void 0 && obj.length >= 0 && typeof obj === 'object';`.
But any other conditional approach would be great too. What matters is typed arrays to be valid arguments.